### PR TITLE
Change padding to make base 36 time keys sortable

### DIFF
--- a/gofid.go
+++ b/gofid.go
@@ -231,9 +231,7 @@ func getBase32TimeKey(time time.Time) (string, error) {
 	paddingLen := ((len(timeKey) - timeKeyLength) * -1)
 
 	if paddingLen > 0 {
-		for index := 0; index < paddingLen; index++ {
-			timeKey = timeKey + paddingChar
-		}
+		timeKey = strings.Repeat("0", paddingLen) + timeKey
 	}
 
 	if paddingLen < 0 {


### PR DESCRIPTION
Made base 36 times sortable by padding with 0 at the start instead of = at the end
